### PR TITLE
Add an entrypoint field and clean up the manifest code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,9 @@ pub struct Package {
         skip_serializing_if = "std::ops::Not::not"
     )]
     pub rename_commands_to_raw_command_name: bool,
+    /// The name of the command that should be used by `wasmer run` by default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]


### PR DESCRIPTION
This PR adds an `entrypoint` field to the `[package]` table (fixes #15).

I've also updated the `Manifest` type to use more intuitive names (e.g. `modules` for a `Vec<Module>` rather than `module`) and removed `Option` from fields in favour of `#[serde(default)]`. All `wasmer.toml` files that used to parse should still parse after this change - it's 100% backwards compatible.

I also changed the `dependencies` field from an `Option<HashMap<String, String>>` to `HashMap<String, VersionReq>` with a `#[serde(default)]`. While it's technically a breaking change because `wasmer.toml` files that used to parse may stop parsing, it should actually be fine because...

- The `wapm2pirita` step merges the `namespace/name` from the `HashMap`'s key and the `version` from the `HashMap`'s and stores it as a `UrlOrManifest::RegistryDependentUrl(format!("{key}@{value}))` [here](https://github.com/wasmerio/pirita/blob/5c4b0e8d538d4a5abf6e7886d1901da744d3a3fe/crates/wapm-targz-to-pirita/src/lib.rs#L411-L426)
- Later on, we will unconditionally error out [here](https://github.com/wasmerio/wasmer/blob/4380bb3fee503f2cf20f3cf9e662bec243111bd9/lib/wasix/src/runtime/resolver/inputs.rs#L318) when we try to parse that `RegistryDependentUrl` as a [`PackageSpecifier`](https://github.com/wasmerio/wasmer/blob/4380bb3fee503f2cf20f3cf9e662bec243111bd9/lib/wasix/src/runtime/resolver/inputs.rs#L20-L38)
- Therefore, any `wasmer.toml` files containing `[dependencies]` entries that don't have a valid `semver::VersionReq` on the right-hand side are broken anyway, and
-  This means we detect the bad `[dependencies]` section at `wasmer publish` time rather than `wasmer run` time 🥳 