### PR TITLE
Make the package field optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,7 +742,7 @@ impl Manifest {
             .map_err(|_e| ManifestError::MissingManifest(manifest_path_buf))?;
         let mut manifest: Self = toml::from_str(contents.as_str())?;
 
-        if let Some(mut package) = manifest.package.clone() {
+        if let Some(mut package) = manifest.package.as_mut() {
             if package.readme.is_none() {
                 package.readme = locate_file(path, README_PATHS);
             }
@@ -750,7 +750,6 @@ impl Manifest {
             if package.license_file.is_none() {
                 package.license_file = locate_file(path, LICENSE_PATHS);
             }
-            manifest.package = Some(package);
         }
         manifest.validate()?;
 


### PR DESCRIPTION
in wasmer.toml, the package field will now be optional. This is to add support
for unnamed packages.

Unnamed packages are useful when you don't want to publish and maintain a
package just for an app. In that case, you can simply associate the package with
a webc hash, instead associating it with a package name/version etc.